### PR TITLE
DNN-18552: fixing accessibility level.

### DIFF
--- a/ClientDependency.Core/CssHelper.cs
+++ b/ClientDependency.Core/CssHelper.cs
@@ -10,7 +10,7 @@ using ClientDependency.Core.Config;
 
 namespace ClientDependency.Core
 {
-    internal static class CssHelper
+    public static class CssHelper
     {
         private static readonly Regex ImportCssRegex = new Regex(@"@import url\((.+?)\);?", RegexOptions.Compiled);
         private static readonly Regex CssUrlRegex = new Regex(@"url\(((?![""']?data:|[""']?#).+?)\)", RegexOptions.Compiled);


### PR DESCRIPTION
This is needed because DNN Web Client library calls the MinifyCSS methods and needs this public accessibility.