### PR TITLE
Updated Build to Create ClientDependency.Core nupkg

### DIFF
--- a/Build-Release.ps1
+++ b/Build-Release.ps1
@@ -39,7 +39,7 @@ $SolutionInfoPath = Join-Path -Path $SolutionRoot -ChildPath "SolutionInfo.cs"
 	sc -Path $SolutionInfoPath -Encoding UTF8
 	
 # Build the solution in release mode (in both 4.0 and 4.5 and for MVC5)
-$SolutionPath = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.sln"
+$SolutionPath = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.dnn.sln"
 
 # clean sln for all deploys
 & $MSBuild "$SolutionPath" /p:Configuration=Release /maxcpucount /t:Clean
@@ -115,29 +115,29 @@ $MvcFolderNet40 = Join-Path -Path $MvcFolder -ChildPath "net40";
 $MvcFolderNet45 = Join-Path -Path $MvcFolder -ChildPath "net45";
 New-Item $MvcFolderNet40 -Type directory
 New-Item $MvcFolderNet45 -Type directory
-Copy-Item "$MvcBinFolderNet40\*.*" -Destination $MvcFolderNet40 -Include $include
-Copy-Item "$MvcBinFolderNet45\*.*" -Destination $MvcFolderNet45 -Include $include
+#Copy-Item "$MvcBinFolderNet40\*.*" -Destination $MvcFolderNet40 -Include $include
+#Copy-Item "$MvcBinFolderNet45\*.*" -Destination $MvcFolderNet45 -Include $include
 #need to build mvc5 separately
 $Mvc5BinFolderNet45 = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Mvc\bin\Release-MVC5";
 $Mvc5FolderNet45 = Join-Path -Path $Mvc5Folder -ChildPath "net45";
 New-Item $Mvc5FolderNet45 -Type directory
-Copy-Item "$Mvc5BinFolderNet45\*.*" -Destination $Mvc5FolderNet45 -Include $include
+#Copy-Item "$Mvc5BinFolderNet45\*.*" -Destination $Mvc5FolderNet45 -Include $include
 
 $include = @('ClientDependency.Less.dll','ClientDependency.Less.pdb')
 $LessBinFolder = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Less\bin\Release";
-Copy-Item "$LessBinFolder\*.*" -Destination $LessFolder -Include $include
+#Copy-Item "$LessBinFolder\*.*" -Destination $LessFolder -Include $include
 
 $include = @('ClientDependency.SASS.dll','ClientDependency.SASS.pdb')
 $SassBinFolder = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.SASS\bin\Release";
-Copy-Item "$SassBinFolder\*.*" -Destination $SassFolder -Include $include
+#Copy-Item "$SassBinFolder\*.*" -Destination $SassFolder -Include $include
 
 $include = @('ClientDependency.Coffee.dll','ClientDependency.Coffee.pdb')
 $CoffeeBinFolder = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Coffee\bin\Release";
-Copy-Item "$CoffeeBinFolder\*.*" -Destination $CoffeeFolder -Include $include
+#Copy-Item "$CoffeeBinFolder\*.*" -Destination $CoffeeFolder -Include $include
 
 $include = @('ClientDependency.TypeScript.dll','ClientDependency.TypeScript.pdb')
 $TypeScriptBinFolder = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.TypeScript\bin\Release";
-Copy-Item "$TypeScriptBinFolder\*.*" -Destination $TypeScriptFolder -Include $include
+#Copy-Item "$TypeScriptBinFolder\*.*" -Destination $TypeScriptFolder -Include $include
 
 # COPY THE TRANSFORMS OVER
 Copy-Item "$BuildFolder\nuget-transforms\Core\web.config.*" -Destination (New-Item (Join-Path -Path $CoreFolder -ChildPath "nuget-transforms") -Type directory);

--- a/ClientDependency.DNN.sln
+++ b/ClientDependency.DNN.sln
@@ -11,6 +11,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution 
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{C5D95718-11A7-4F12-A41A-10229A87F428}"
 	ProjectSection(SolutionItems) = preProject
+		appveyor.yml = appveyor.yml
 		Build-Release.ps1 = Build-Release.ps1
 		build\ClientDependency-Coffee.nuspec = build\ClientDependency-Coffee.nuspec
 		build\ClientDependency-Less.nuspec = build\ClientDependency-Less.nuspec

--- a/ClientDependency.DNN.sln
+++ b/ClientDependency.DNN.sln
@@ -1,0 +1,117 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio 15
+VisualStudioVersion = 15.0.27703.1
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{09017A90-7F59-40F8-8121-8B4284697BBD}"
+	ProjectSection(SolutionItems) = preProject
+		README.md = README.md
+		SolutionInfo.cs = SolutionInfo.cs
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Build", "Build", "{C5D95718-11A7-4F12-A41A-10229A87F428}"
+	ProjectSection(SolutionItems) = preProject
+		Build-Release.ps1 = Build-Release.ps1
+		build\ClientDependency-Coffee.nuspec = build\ClientDependency-Coffee.nuspec
+		build\ClientDependency-Less.nuspec = build\ClientDependency-Less.nuspec
+		build\ClientDependency-Mvc.nuspec = build\ClientDependency-Mvc.nuspec
+		build\ClientDependency-Mvc5.nuspec = build\ClientDependency-Mvc5.nuspec
+		build\ClientDependency-SASS.nuspec = build\ClientDependency-SASS.nuspec
+		build\ClientDependency-TypeScript.nuspec = build\ClientDependency-TypeScript.nuspec
+		build\ClientDependency.nuspec = build\ClientDependency.nuspec
+		UpgradingUmbraco.txt = UpgradingUmbraco.txt
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Config Transforms", "Config Transforms", "{37C50F26-9EDE-45F6-BDCC-39F51E0E312C}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Mvc", "Mvc", "{D8142A9E-6FDC-46BC-9767-F63767C46887}"
+	ProjectSection(SolutionItems) = preProject
+		build\nuget-transforms\Mvc\web.config.transform = build\nuget-transforms\Mvc\web.config.transform
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Core", "Core", "{4D8DC7DA-0202-4338-B154-72A077FA88E8}"
+	ProjectSection(SolutionItems) = preProject
+		build\nuget-transforms\Core\web.config.install.xdt = build\nuget-transforms\Core\web.config.install.xdt
+		build\nuget-transforms\Core\web.config.uninstall.xdt = build\nuget-transforms\Core\web.config.uninstall.xdt
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{86C3F7CD-2FDA-4025-805B-7DC6C8A44DDA}"
+	ProjectSection(SolutionItems) = preProject
+		.nuget\NuGet.Config = .nuget\NuGet.Config
+		.nuget\NuGet.exe = .nuget\NuGet.exe
+		.nuget\NuGet.targets = .nuget\NuGet.targets
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Less", "Less", "{3EAA2D5D-A830-4BA8-90AE-FBB8B307B3FD}"
+	ProjectSection(SolutionItems) = preProject
+		build\nuget-transforms\Less\web.config.transform = build\nuget-transforms\Less\web.config.transform
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Coffee", "Coffee", "{761DC809-2861-4C89-8EA2-CF55304A1FD1}"
+	ProjectSection(SolutionItems) = preProject
+		build\nuget-transforms\Coffee\web.config.transform = build\nuget-transforms\Coffee\web.config.transform
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Sass", "Sass", "{9598A99A-018C-405C-ACAA-75D7165F3104}"
+	ProjectSection(SolutionItems) = preProject
+		build\nuget-transforms\SASS\web.config.transform = build\nuget-transforms\SASS\web.config.transform
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "TypeScript", "TypeScript", "{CABF4276-D3DD-4497-BF63-B7527A91A1D8}"
+	ProjectSection(SolutionItems) = preProject
+		build\nuget-transforms\TypeScript\web.config.transform = build\nuget-transforms\TypeScript\web.config.transform
+	EndProjectSection
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ClientDependency.Core", "ClientDependency.Core\ClientDependency.Core.csproj", "{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Umbraco4.ClientDependency", "Umbraco4.ClientDependency\Umbraco4.ClientDependency.csproj", "{08DFBA02-97A5-496C-9272-09CE98C50BF5}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug-MVC5|Any CPU = Debug-MVC5|Any CPU
+		Debug-Net45|Any CPU = Debug-Net45|Any CPU
+		Release|Any CPU = Release|Any CPU
+		Release-MVC5|Any CPU = Release-MVC5|Any CPU
+		Release-Net45|Any CPU = Release-Net45|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-MVC5|Any CPU.ActiveCfg = Debug-Net45|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-MVC5|Any CPU.Build.0 = Debug-Net45|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-Net45|Any CPU.ActiveCfg = Debug-Net45|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-Net45|Any CPU.Build.0 = Debug-Net45|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release|Any CPU.Build.0 = Release|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-MVC5|Any CPU.ActiveCfg = Release-Net45|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-MVC5|Any CPU.Build.0 = Release-Net45|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-Net45|Any CPU.ActiveCfg = Release-Net45|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-Net45|Any CPU.Build.0 = Release-Net45|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Debug-MVC5|Any CPU.ActiveCfg = Debug|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Debug-Net45|Any CPU.ActiveCfg = Debug|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Release-MVC5|Any CPU.ActiveCfg = Release|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Release-MVC5|Any CPU.Build.0 = Release|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Release-Net45|Any CPU.ActiveCfg = Release|Any CPU
+		{08DFBA02-97A5-496C-9272-09CE98C50BF5}.Release-Net45|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{37C50F26-9EDE-45F6-BDCC-39F51E0E312C} = {C5D95718-11A7-4F12-A41A-10229A87F428}
+		{D8142A9E-6FDC-46BC-9767-F63767C46887} = {37C50F26-9EDE-45F6-BDCC-39F51E0E312C}
+		{4D8DC7DA-0202-4338-B154-72A077FA88E8} = {37C50F26-9EDE-45F6-BDCC-39F51E0E312C}
+		{3EAA2D5D-A830-4BA8-90AE-FBB8B307B3FD} = {37C50F26-9EDE-45F6-BDCC-39F51E0E312C}
+		{761DC809-2861-4C89-8EA2-CF55304A1FD1} = {37C50F26-9EDE-45F6-BDCC-39F51E0E312C}
+		{9598A99A-018C-405C-ACAA-75D7165F3104} = {37C50F26-9EDE-45F6-BDCC-39F51E0E312C}
+		{CABF4276-D3DD-4497-BF63-B7527A91A1D8} = {37C50F26-9EDE-45F6-BDCC-39F51E0E312C}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {4C38899F-9719-49EE-9862-7F1A265F9250}
+	EndGlobalSection
+EndGlobal

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,15 @@
+version: 1.8.4.{build}
+pull_requests:
+  do_not_increment_build_number: true
+branches:
+  only:
+  - dnn
+image: Visual Studio 2017
+nuget:
+  project_feed: true
+  disable_publish_on_pr: true
+build_script:
+- ps: .\Build-Release.ps1 $env:APPVEYOR_BUILD_VERSION ''
+artifacts:
+- path: build\Releases\**\*.nupkg
+  name: NuGet


### PR DESCRIPTION
Updated project/build to support changes for dnnsoftware/Dnn.Platform

* Created new sln file for building just the `ClientDependency.Core` project which is used by the Dnn Platform. This new sln file excludes projects that were causing build issues
* Updated build script to to comment out copy commands that were failing for projects we don't care about for the platform
* Added new appveyor.yml file for a shared build configuration that exports the nupkg files as part of the build.
* Configured appveyor project NuGet feed (this needs to be discussed a little more)
    * I am not 100% sure what our plan is for releasing the artifacts as NuGets

Versioning:

* I followed the current ClientDependency versioning strategy starting at version 1.8.4, if we would like to change this we can simply just update teh appveyor.yml file.

Fixes: dnnsoftware/Dnn.Platform#2061