### PR TITLE
Add support for replacing CSS files with .rtl.css versions for RTL cultures

### DIFF
--- a/Build-Release.ps1
+++ b/Build-Release.ps1
@@ -68,20 +68,20 @@ Write-Host "MSBUILD = $MSBuild"
 $SolutionInfoPath = Join-Path -Path $SolutionRoot -ChildPath "SolutionInfo.cs"
 (gc -Path $SolutionInfoPath) `
 	-replace "(?<=Version\(`")[.\d]*(?=`"\))", $ReleaseVersionNumber |
-	sc -Path $SolutionInfoPath -Encoding UTF8
+	Set-Content -Path $SolutionInfoPath -Encoding UTF8
 (gc -Path $SolutionInfoPath) `
 	-replace "(?<=AssemblyInformationalVersion\(`")[.\w-]*(?=`"\))", "$ReleaseVersionNumber$PreReleaseName" |
-	sc -Path $SolutionInfoPath -Encoding UTF8
+	Set-Content -Path $SolutionInfoPath -Encoding UTF8
 # Set the copyright
 (gc -Path $SolutionInfoPath) `
 	-replace "(?<=AssemblyCopyright\(`".*?)\d\d\d\d(?=`"\))", (Get-Date).year |
-	sc -Path $SolutionInfoPath -Encoding UTF8
+	Set-Content -Path $SolutionInfoPath -Encoding UTF8
 	
 # Build the solution in release mode (in both 4.0 and 4.5 and for MVC5)
 $SolutionPath = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.dnn.sln"
 
 # clean sln for all deploys
-& $MSBuild "$SolutionPath" /p:Configuration=Release-Net45 /maxcpucount /t:Clean
+& $MSBuild "$SolutionPath" /p:Configuration=Release-Net48 /maxcpucount /t:Clean
 if (-not $?)
 {
 	throw "The MSBuild process returned an error code."
@@ -91,7 +91,7 @@ if (-not $?)
 {
 	throw "The MSBuild process returned an error code."
 }
-& $MSBuild "$SolutionPath" /p:Configuration=Release-Net45 /maxcpucount /t:Clean
+& $MSBuild "$SolutionPath" /p:Configuration=Release-Net48 /maxcpucount /t:Clean
 if (-not $?)
 {
 	throw "The MSBuild process returned an error code."
@@ -109,7 +109,7 @@ Write-Host "Restoring nuget packages..."
 #build for all deploys
 
 # for net 3.5
-& $MSBuild "$SolutionPath" /p:Configuration=Release-Net45 /maxcpucount
+& $MSBuild "$SolutionPath" /p:Configuration=Release-Net48 /maxcpucount
 if (-not $?)
 {
 	throw "The MSBuild process returned an error code."
@@ -120,8 +120,8 @@ if (-not $?)
 {
 	throw "The MSBuild process returned an error code."
 }
-# for net 4.5
-& $MSBuild "$SolutionPath" /p:Configuration=Release-Net45 /maxcpucount
+# for net 4.8
+& $MSBuild "$SolutionPath" /p:Configuration=Release-Net48 /maxcpucount
 if (-not $?)
 {
 	throw "The MSBuild process returned an error code."
@@ -152,23 +152,23 @@ New-Item $TypeScriptFolder -Type directory
 
 $include = @('ClientDependency.Core.dll','ClientDependency.Core.pdb')
 # Need to build to specific .Net version folders
-$CoreBinFolderNet45 = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Core\bin\Release-Net45";
-$CoreFolderNet45 = Join-Path -Path $CoreFolder -ChildPath "net45";
+$CoreBinFolderNet48 = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Core\bin\Release-Net48";
+$CoreFolderNet48 = Join-Path -Path $CoreFolder -ChildPath "net48";
 
-New-Item $CoreFolderNet45 -Type directory
-Copy-Item "$CoreBinFolderNet45\*.*" -Destination $CoreFolderNet45 -Include $include
+New-Item $CoreFolderNet48 -Type directory
+Copy-Item "$CoreBinFolderNet48\*.*" -Destination $CoreFolderNet48 -Include $include
 
 $include = @('ClientDependency.Core.Mvc.dll','ClientDependency.Core.Mvc.pdb')
 # Need to build to specific .Net version folders
-$MvcBinFolderNet45 = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Mvc\bin\Release-Net45";
-$MvcFolderNet45 = Join-Path -Path $MvcFolder -ChildPath "net45";
-New-Item $MvcFolderNet45 -Type directory
-#Copy-Item "$MvcBinFolderNet45\*.*" -Destination $MvcFolderNet45 -Include $include
+$MvcBinFolderNet48 = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Mvc\bin\Release-Net48";
+$MvcFolderNet48 = Join-Path -Path $MvcFolder -ChildPath "net48";
+New-Item $MvcFolderNet48 -Type directory
+#Copy-Item "$MvcBinFolderNet48\*.*" -Destination $MvcFolderNet48 -Include $include
 #need to build mvc5 separately
-$Mvc5BinFolderNet45 = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Mvc\bin\Release-MVC5";
-$Mvc5FolderNet45 = Join-Path -Path $Mvc5Folder -ChildPath "net45";
-New-Item $Mvc5FolderNet45 -Type directory
-#Copy-Item "$Mvc5BinFolderNet45\*.*" -Destination $Mvc5FolderNet45 -Include $include
+$Mvc5BinFolderNet48 = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Mvc\bin\Release-MVC5";
+$Mvc5FolderNet48 = Join-Path -Path $Mvc5Folder -ChildPath "net48";
+New-Item $Mvc5FolderNet48 -Type directory
+#Copy-Item "$Mvc5BinFolderNet48\*.*" -Destination $Mvc5FolderNet48 -Include $include
 
 $include = @('ClientDependency.Less.dll','ClientDependency.Less.pdb')
 $LessBinFolder = Join-Path -Path $SolutionRoot -ChildPath "ClientDependency.Less\bin\Release";

--- a/build/ClientDependency-Mvc.nuspec
+++ b/build/ClientDependency-Mvc.nuspec
@@ -22,8 +22,8 @@
     </dependencies>
   </metadata>
   <files>
-    <file src="net45\*.dll" target="lib\net45" />
-    <file src="net45\*.pdb" target="lib\net45" />
+    <file src="net48\*.dll" target="lib\net48" />
+    <file src="net48\*.pdb" target="lib\net48" />
 
     <file src="nuget-transforms\web.config.transform" target="Content" />
 

--- a/build/ClientDependency-Mvc5.nuspec
+++ b/build/ClientDependency-Mvc5.nuspec
@@ -23,8 +23,8 @@
   </metadata>
   <files>
 
-    <file src="net45\*.dll" target="lib\net45" />
-    <file src="net45\*.pdb" target="lib\net45" />
+    <file src="net48\*.dll" target="lib\net48" />
+    <file src="net48\*.pdb" target="lib\net48" />
 
     <file src="nuget-transforms\web.config.transform" target="Content" />
 

--- a/build/ClientDependency.nuspec
+++ b/build/ClientDependency.nuspec
@@ -16,8 +16,8 @@
         <repository type="git" url="https://github.com/dnnsoftware/ClientDependency" />
     </metadata>
     <files>
-        <file src="net45\*.dll" target="lib\net45" />
-        <file src="net45\*.pdb" target="lib\net45" />
+        <file src="net48\*.dll" target="lib\net48" />
+        <file src="net48\*.pdb" target="lib\net48" />
 
         <file src="nuget-transforms\web.config.install.xdt" target="Content" />
         <file src="nuget-transforms\web.config.uninstall.xdt" target="Content" />

--- a/src/ClientDependency.Core/ClientDependency.Core.csproj
+++ b/src/ClientDependency.Core/ClientDependency.Core.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClientDependency.Core</RootNamespace>
     <AssemblyName>ClientDependency.Core</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -42,7 +42,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>SecurityRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -53,7 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
@@ -62,26 +62,26 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>cdf.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-Net45|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-Net48|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug-Net45\</OutputPath>
+    <OutputPath>bin\Debug-Net48\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-Net45|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-Net48|AnyCPU'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release-Net45\</OutputPath>
+    <OutputPath>bin\Release-Net48\</OutputPath>
     <DefineConstants>TRACE;MVC</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Release-Net35|AnyCPU'">

--- a/src/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
+++ b/src/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
@@ -294,6 +294,7 @@ namespace ClientDependency.Core.FileRegistration.Providers
                     var resolvedPath = path.ResolvePath(http);
                     var basePath = resolvedPath.EndsWith("/") ? resolvedPath : resolvedPath + "/";
                     dependency.FilePath = basePath + dependency.FilePath;
+
                     // Replace CSS file with its RTL version if the current culture is right-to-left and the RTL file exists
                     if (System.Globalization.CultureInfo.CurrentCulture.TextInfo.IsRightToLeft && dependency.FilePath.EndsWith(".css", StringComparison.OrdinalIgnoreCase) && !dependency.FilePath.Contains("http"))
                     {

--- a/src/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
+++ b/src/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
@@ -296,7 +296,10 @@ namespace ClientDependency.Core.FileRegistration.Providers
                     dependency.FilePath = basePath + dependency.FilePath;
 
                     // Replace CSS file with its RTL version if the current culture is right-to-left and the RTL file exists
-                    if (System.Globalization.CultureInfo.CurrentCulture.TextInfo.IsRightToLeft && dependency.FilePath.EndsWith(".css", StringComparison.OrdinalIgnoreCase) && !dependency.FilePath.Contains("http"))
+                    if (System.Globalization.CultureInfo.CurrentCulture.TextInfo.IsRightToLeft && 
+                        dependency.FilePath.EndsWith(".css", StringComparison.OrdinalIgnoreCase) &&
+                        !dependency.FilePath.EndsWith(".rtl.css", StringComparison.OrdinalIgnoreCase) &&
+                        !dependency.FilePath.Contains("http"))
                     {
                         var rtlFilePath = dependency.FilePath.Replace(".css", ".rtl.css");
                         var serverPath = HttpContext.Current.Server.MapPath(rtlFilePath);

--- a/src/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
+++ b/src/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
@@ -294,6 +294,17 @@ namespace ClientDependency.Core.FileRegistration.Providers
                     var resolvedPath = path.ResolvePath(http);
                     var basePath = resolvedPath.EndsWith("/") ? resolvedPath : resolvedPath + "/";
                     dependency.FilePath = basePath + dependency.FilePath;
+                    // Replace CSS file with its RTL version if the current culture is right-to-left and the RTL file exists
+                    if (System.Globalization.CultureInfo.CurrentCulture.TextInfo.IsRightToLeft && dependency.FilePath.EndsWith(".css", StringComparison.OrdinalIgnoreCase) && !dependency.FilePath.Contains("http"))
+                    {
+                        var rtlFilePath = dependency.FilePath.Replace(".css", ".rtl.css");
+                        var serverPath = HttpContext.Current.Server.MapPath(rtlFilePath);
+
+                        if (System.IO.File.Exists(serverPath))
+                        {
+                            dependency.FilePath = rtlFilePath;
+                        }
+                    }
                     dependency.ForceBundle = (dependency.ForceBundle | path.ForceBundle);
                 }
                 else

--- a/src/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
+++ b/src/ClientDependency.Core/FileRegistration/Providers/BaseFileRegistrationProvider.cs
@@ -294,26 +294,23 @@ namespace ClientDependency.Core.FileRegistration.Providers
                     var resolvedPath = path.ResolvePath(http);
                     var basePath = resolvedPath.EndsWith("/") ? resolvedPath : resolvedPath + "/";
                     dependency.FilePath = basePath + dependency.FilePath;
-
-                    // Replace CSS file with its RTL version if the current culture is right-to-left and the RTL file exists
-                    if (System.Globalization.CultureInfo.CurrentCulture.TextInfo.IsRightToLeft && 
-                        dependency.FilePath.EndsWith(".css", StringComparison.OrdinalIgnoreCase) &&
-                        !dependency.FilePath.EndsWith(".rtl.css", StringComparison.OrdinalIgnoreCase) &&
-                        !dependency.FilePath.Contains("http"))
-                    {
-                        var rtlFilePath = dependency.FilePath.Replace(".css", ".rtl.css");
-                        var serverPath = HttpContext.Current.Server.MapPath(rtlFilePath);
-
-                        if (System.IO.File.Exists(serverPath))
-                        {
-                            dependency.FilePath = rtlFilePath;
-                        }
-                    }
                     dependency.ForceBundle = (dependency.ForceBundle | path.ForceBundle);
                 }
                 else
                 {
                     dependency.FilePath = dependency.ResolveFilePath(http);
+                }
+
+                // Replace CSS file with its RTL version if the current culture is right-to-left and the RTL file exists
+                if (System.Globalization.CultureInfo.CurrentCulture.TextInfo.IsRightToLeft &&
+                    !dependency.FilePath.StartsWith("http", StringComparison.OrdinalIgnoreCase) &&
+                    PathHelper.TryGetFileExtension(dependency.FilePath, out var ext))
+                {
+                    var rtlFilePath = Path.ChangeExtension(dependency.FilePath, ".rtl" + ext);
+                    if (PathHelper.TryMapPath(rtlFilePath, http, out var serverPath) && File.Exists(serverPath))
+                    {
+                        dependency.FilePath = rtlFilePath;
+                    }
                 }
 
                 //append query strings to each file if we are in debug mode

--- a/src/ClientDependency.DNN.sln
+++ b/src/ClientDependency.DNN.sln
@@ -69,24 +69,24 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug-MVC5|Any CPU = Debug-MVC5|Any CPU
-		Debug-Net45|Any CPU = Debug-Net45|Any CPU
+		Debug-Net48|Any CPU = Debug-Net48|Any CPU
 		Release|Any CPU = Release|Any CPU
 		Release-MVC5|Any CPU = Release-MVC5|Any CPU
-		Release-Net45|Any CPU = Release-Net45|Any CPU
+		Release-Net48|Any CPU = Release-Net48|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-MVC5|Any CPU.ActiveCfg = Debug-Net45|Any CPU
-		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-MVC5|Any CPU.Build.0 = Debug-Net45|Any CPU
-		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-Net45|Any CPU.ActiveCfg = Debug-Net45|Any CPU
-		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-Net45|Any CPU.Build.0 = Debug-Net45|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-MVC5|Any CPU.ActiveCfg = Debug-Net48|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-MVC5|Any CPU.Build.0 = Debug-Net48|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-Net48|Any CPU.ActiveCfg = Debug-Net48|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug-Net48|Any CPU.Build.0 = Debug-Net48|Any CPU
 		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release|Any CPU.Build.0 = Release|Any CPU
-		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-MVC5|Any CPU.ActiveCfg = Release-Net45|Any CPU
-		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-MVC5|Any CPU.Build.0 = Release-Net45|Any CPU
-		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-Net45|Any CPU.ActiveCfg = Release-Net45|Any CPU
-		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-Net45|Any CPU.Build.0 = Release-Net45|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-MVC5|Any CPU.ActiveCfg = Release-Net48|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-MVC5|Any CPU.Build.0 = Release-Net48|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-Net48|Any CPU.ActiveCfg = Release-Net48|Any CPU
+		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Release-Net48|Any CPU.Build.0 = Release-Net48|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/ClientDependency.Mvc/ClientDependency.Core.Mvc.csproj
+++ b/src/ClientDependency.Mvc/ClientDependency.Core.Mvc.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClientDependency.Core.Mvc</RootNamespace>
     <AssemblyName>ClientDependency.Core.Mvc</AssemblyName>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <SccProjectName>
     </SccProjectName>
@@ -42,7 +42,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
@@ -53,7 +53,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup>
@@ -62,26 +62,26 @@
   <PropertyGroup>
     <AssemblyOriginatorKeyFile>cdf.snk</AssemblyOriginatorKeyFile>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-Net45|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-Net48|AnyCPU'">
     <DebugSymbols>true</DebugSymbols>
-    <OutputPath>bin\Debug-Net45\</OutputPath>
+    <OutputPath>bin\Debug-Net48\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <DebugType>full</DebugType>
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-Net45|AnyCPU'">
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-Net48|AnyCPU'">
     <DebugType>pdbonly</DebugType>
     <Optimize>true</Optimize>
-    <OutputPath>bin\Release-Net45\</OutputPath>
+    <OutputPath>bin\Release-Net48\</OutputPath>
     <DefineConstants>TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug-MVC5|AnyCPU'">
@@ -92,7 +92,7 @@
     <PlatformTarget>AnyCPU</PlatformTarget>
     <ErrorReport>prompt</ErrorReport>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release-MVC5|AnyCPU'">
@@ -103,7 +103,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodeAnalysisRuleSet>AllRules.ruleset</CodeAnalysisRuleSet>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <PlatformTarget>AnyCPU</PlatformTarget>
   </PropertyGroup>
   <ItemGroup>

--- a/src/ClientDependency.UnitTests/ClientDependency.UnitTests.csproj
+++ b/src/ClientDependency.UnitTests/ClientDependency.UnitTests.csproj
@@ -13,7 +13,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClientDependency.UnitTests</RootNamespace>
     <AssemblyName>ClientDependency.UnitTests</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <SccProjectName>

--- a/src/ClientDependency.Web.Test/ClientDependency.Web.Test.csproj
+++ b/src/ClientDependency.Web.Test/ClientDependency.Web.Test.csproj
@@ -12,7 +12,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>ClientDependency.Web.Test</RootNamespace>
     <AssemblyName>ClientDependency.Web.Test</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <SccProjectName>
     </SccProjectName>
     <SccLocalPath>

--- a/src/ClientDependency.sln
+++ b/src/ClientDependency.sln
@@ -79,11 +79,11 @@ Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Debug-MVC5|Any CPU = Debug-MVC5|Any CPU
-		Debug-Net45|Any CPU = Debug-Net45|Any CPU
+		Debug-Net48|Any CPU = Debug-Net48|Any CPU
 		Release|Any CPU = Release|Any CPU
 		Release-MVC5|Any CPU = Release-MVC5|Any CPU
 		Release-Net35|Any CPU = Release-Net35|Any CPU
-		Release-Net45|Any CPU = Release-Net45|Any CPU
+		Release-Net48|Any CPU = Release-Net48|Any CPU
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{EA35B06D-0CC8-4830-A3F7-9BB3D36D0FAF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -2,7 +2,7 @@ using System.Reflection;
 using System.Security;
 
 [assembly: AssemblyCompany("Shannon Deminick")]
-[assembly: AssemblyCopyright("Copyright © Shannon Deminick 2021")]
+[assembly: AssemblyCopyright("Copyright © Shannon Deminick 2025")]
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")] 
 


### PR DESCRIPTION
This change adds functionality to check if the current culture is right-to-left (RTL) and replace the CSS file with its corresponding .rtl.css version if it exists.

This approach allows RTL-specific styles to be kept in separate CSS files rather than merging them into the main CSS, which:
- Prevents bloating the default CSS files with RTL overrides
- Improves site performance by loading only necessary styles
- Keeps RTL styles modular and easier to maintain

In summary, it optimises loading for RTL cultures by using dedicated .rtl.css files when available.

Note: This approach has been tested and used for over 4 years in the repository below without issues:
[Persian-DnnSoftware/ClientDependency](https://github.com/Persian-DnnSoftware/ClientDependency
)